### PR TITLE
fix: Updating git-url-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/storybooks/storybook-deployer.git"
   },
   "dependencies": {
-    "git-url-parse": "^8.1.0",
+    "git-url-parse": "^11.1.2",
     "glob": "^7.1.3",
     "parse-repo": "^1.0.4",
     "shelljs": "^0.8.1",


### PR DESCRIPTION
This new version doesn't have colon on the user or organization name, fixes #64