### PR TITLE
Log ref.stderr instead of shell.stderr

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ module.exports.exec = function exec(command) {
   }
 
   throw new Error(
-    `Exec code(${ref.code}) on executing: ${command}\n${shell.stderr}`
+    `Exec code(${ref.code}) on executing: ${command}\n${ref.stderr}`
   );
 };
 


### PR DESCRIPTION
### What?
When `exec` returns with code 1 throw an error that includes `ref.stderr` instead of `shell.stderr`.

### Why?
Fixes: https://github.com/storybookjs/storybook-deployer/issues/72