### PR TITLE
Add AWS S3 sync options

### DIFF
--- a/bin/storybook_to_aws_s3
+++ b/bin/storybook_to_aws_s3
@@ -30,7 +30,7 @@ if (args.DRY_RUN) {
 
 console.log('=> Deploying storybook');
 publishUtils.exec(
-  `aws --profile ${args.AWS_PROFILE} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH} ${args.S3_SYNC_OPTIONS}`
+  `aws --profile ${args.AWS_PROFILE} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH} ${args.S3_SYNC_OPTIONS || ''}`
 );
 
 shell.rm('-rf', args.OUTPUT_DIR);

--- a/bin/storybook_to_aws_s3
+++ b/bin/storybook_to_aws_s3
@@ -30,7 +30,7 @@ if (args.DRY_RUN) {
 
 console.log('=> Deploying storybook');
 publishUtils.exec(
-  `aws --profile ${args.AWS_PROFILE} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH}`
+  `aws --profile ${args.AWS_PROFILE} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH} ${args.S3_SYNC_OPTIONS}`
 );
 
 shell.rm('-rf', args.OUTPUT_DIR);

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -6,7 +6,7 @@ const defaultConfig = {
   commitMessage: 'Deploy Storybook to GitHub Pages'
 };
 
-const argv = yargs
+const { argv } = yargs
   .wrap(yargs.terminalWidth())
   .option('help', {
     alias: 'h',
@@ -80,7 +80,11 @@ const argv = yargs
   .option('bucket-path', {
     desc: 'AWS bucket path to use for publishing',
     type: 'string'
-  }).argv;
+  })
+  .option('s3-sync-options', {
+    desc: 'Additional options to pass to AWSCLI s3 sync',
+    type: 'string'
+  });
 
 module.exports = packageJson => {
   const HOST_TOKEN_ENV_VARIABLE = argv['host-token-env-variable'] || 'GH_TOKEN';
@@ -109,6 +113,7 @@ module.exports = packageJson => {
     // AWS Variables
     AWS_PROFILE: argv['aws-profile'] || 'default',
     BUCKET_PATH: argv['bucket-path'],
-    S3_PATH: 's3://' + argv['bucket-path']
+    S3_PATH: 's3://' + argv['bucket-path'],
+    S3_SYNC_OPTIONS: argv['s3-sync-options'],
   };
 };


### PR DESCRIPTION
This PR allows you to specify arbitrary additional arguments to `--s3-sync-options`.

Example usage:
```
storybook-to-aws-s3 --bucket-path=bucket-name/bucket-path --s3-sync-options=--acl=public-read
storybook-to-aws-s3 --bucket-path=bucket-name/bucket-path --s3-sync-options="--acl=public-read --quiet"
```

Addresses #75 