### PR TITLE
Stop burying stderr output within exec

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,11 @@ module.exports.exec = function exec(command) {
   if (ref.code === 0) {
     return ref.stdout.trim();
   }
+  
+  // If the failed shell exec has meaningful error output, do not bury it:
+  if (ref.stderr.trim()) {
+    console.error(ref.stderr);
+  }
 
   throw new Error(
     `Exec code(${ref.code}) on executing: ${command}\n${shell.stderr}`


### PR DESCRIPTION
The exec util buries stderr output. This makes it difficult to understand why your script is failing.

Example: Here's how it currently works. Notice there is nothing specific about what went wrong in the error output:

```sh
npm run storybook:publish -- --bucket-path=XXXXXXXXXXXXXX

=> Building storybook for: web
   executing: build-storybook  -o out8599
=> Deploying storybook
   executing: aws --profile default s3 sync out8599 s3://XXXXXXXXXXXXXX

/......../node_modules/@storybook/storybook-deployer/src/utils.js:19
  throw new Error(
  ^

Error: Exec code(255) on executing: aws --profile default s3 sync out8599 s3://XXXXXXXXXXXXXX
undefined
```

Result: Here's what happens with this patch:

```sh
npm run storybook:publish -- --bucket-path=XXXXXXXXXXXXXX

=> Building storybook for: web
   executing: build-storybook  -o out8599
=> Deploying storybook
   executing: aws --profile default s3 sync out8599 s3://XXXXXXXXXXXXXX

The config profile (default) could not be found

/......../node_modules/@storybook/storybook-deployer/src/utils.js:19
  throw new Error(
  ^

Error: Exec code(255) on executing: aws --profile default s3 sync out8599 s3://XXXXXXXXXXXXXX
undefined
```

We can now see the source of the error as indicated by the command which we executed:

> The config profile (default) could not be found