### PR TITLE
Make it possible to exclude use of the AWS `--profile` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a simple tool allows you to deploy your Storybook into a static hosting 
 
 ```sh
 $ storybook-to-ghpages --help
+$ storybook-to-aws-s3 --help
 
 Options:
   --help, -h                      Show help.                                             [boolean]
@@ -21,7 +22,8 @@ Options:
   --branch                        Git branch to push to             [string] [default: "gh-pages"]
   --source-branch                 Source branch to push from          [string] [default: "master"]
   --host-token-env-variable, -t   Github token for CI publish       [string] [default: "GH_TOKEN"]
-  --aws-profile                   AWS profile to use for publishing  [string] [default: "default"]
+  --aws-profile                   AWS profile to use for publishing. Use NONE to use no profile
+                                  at all instead of "default".       [string] [default: "default"]
   --bucket-path                   AWS bucket path to use for publishing                   [string]
 ```
 
@@ -182,3 +184,7 @@ You must specify a bucket path with `bucket-path` option: `my-bucket-name/path/t
 You can change the aws profile used to run the command with the `aws-profile` option.
 
 example: `storybook-to-aws-s3 --bucket-path=my-bucket-name/path/to/destination-folder-in-bucket --aws-profile=myprofile`
+
+You can exclude the aws profile by setting this flag to "NONE":
+
+example: `storybook-to-aws-s3 --bucket-path=my-bucket-name/path/to/destination-folder-in-bucket --aws-profile=NONE`

--- a/bin/storybook_to_aws_s3
+++ b/bin/storybook_to_aws_s3
@@ -28,9 +28,14 @@ if (args.DRY_RUN) {
   return;
 }
 
+// If a system does not use an AWS profile we have to exclude the flag entirely.
+// This is indicated by AWS_PROFILE='NONE'.
+const awsProfile =
+  args.AWS_PROFILE === 'NONE' ? '' : `--profile ${args.AWS_PROFILE}`;
+
 console.log('=> Deploying storybook');
 publishUtils.exec(
-  `aws --profile ${args.AWS_PROFILE} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH}`
+  `aws ${awsProfile} s3 sync ${args.OUTPUT_DIR} ${args.S3_PATH}`
 );
 
 shell.rm('-rf', args.OUTPUT_DIR);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/storybook-deployer",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Deploy your storybook as a webapp.",
   "keywords": [
     "deploy",

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -73,7 +73,8 @@ const argv = yargs
   })
   // AWS Variables
   .option('aws-profile', {
-    desc: 'AWS profile to use for publishing',
+    desc:
+      'AWS profile to use for publishing. Use NONE to exclude the --profile flag.',
     type: 'string',
     default: 'default'
   })


### PR DESCRIPTION
This patch makes it possible to exclude the AWS `--profile` flag from the `aws s3 sync` command. 

This is necessary because some systems (like CI) store credentials in environmental variables automatically detected by `aws` rather than having them associated with an AWS profile. Without this patch the script fails with:

```
The config profile (default) could not be found
```

To trigger this behavior you pass `NONE` to the script like so:

```
storybook-to-aws-s3 --aws-profile=NONE ...
```

The README and CLI docs have been updated to note this capability.