### PR TITLE
Remove check for Github.com when using an access token

### DIFF
--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -59,7 +59,7 @@ console.log('=> Deploying storybook');
 if (args.CI_DEPLOY) {
   const { host, repository } = parseRepo(GIT_URL);
 
-  if (host === 'github.com' && args.HOST_TOKEN) {
+  if (args.HOST_TOKEN) {
     GIT_URL = `https://${args.HOST_TOKEN}@${host}/${repository}`;
   }
 }


### PR DESCRIPTION
This check isn't required and have successfully tested using a GitHub enterprise server. This tool doesn't work for me in CI without this change since I am not using SSH for auth