### PR TITLE
Automatically use CI mode if CI env variable is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ npm run deploy-storybook -- --monorepo-index-generator my-custom-generator.js
 
 To deploy Storybook as part of a CI step, pass the `ci` flag to `npm run deploy-storybook`.
 
+If the `CI` environment variable is set then this mode will be assumed, therefore no need to specify the `ci` flag.
+
 Because pushing to GitHub as part of a CI step requires a [personal access token](https://github.com/blog/1509-personal-api-tokens), Storybook uses the `GH_TOKEN` environment variable, by default, to authenticate GitHub pushes.
 
 This environment variable name can be configured via the `host-token-env-variable` flag.
@@ -238,6 +240,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -104,7 +104,7 @@ module.exports = packageJson => {
     PACKAGES_DIRECTORY: argv.packages,
     MONOREPO_INDEX_GENERATOR: argv['monorepo-index-generator'],
     NPM_SCRIPT: argv.script || 'build-storybook',
-    CI_DEPLOY: Boolean(argv.ci),
+    CI_DEPLOY: Boolean(argv.ci) || Boolean(process.env.CI),
     DRY_RUN: Boolean(argv.dryRun),
     // Git Variables
     GIT_REMOTE: argv.remote || 'origin',
@@ -115,6 +115,6 @@ module.exports = packageJson => {
     AWS_PROFILE: argv['aws-profile'] || 'default',
     BUCKET_PATH: argv['bucket-path'],
     S3_PATH: 's3://' + argv['bucket-path'],
-    S3_SYNC_OPTIONS: argv['s3-sync-options'],
+    S3_SYNC_OPTIONS: argv['s3-sync-options']
   };
 };


### PR DESCRIPTION
I proposed this here: https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-670051715 

I think that automatically turning on CI mode if the environment variable is present is a good nice to have and very low effort to add in with little risk.
Most CI providers have this environment variable set and for those that don't they can just use the argument as before.
