### PR TITLE
Add `npx` instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ or like this for AWS S3:
 
 Then you can run `npm run deploy-storybook` to deploy the Storybook.
 
+Alternatively, you can execute Storybook Deployer directly using `npx`
+
+```sh
+npx -p @storybook/storybook-deployer storybook-to-ghpages
+npx -p @storybook/storybook-deployer storybook-to-aws-s3
+```
+
 ### Custom Build Configuration
 
 If you customize the build configuration with some additional params (like static file directory), then you need to expose another NPM script like this:


### PR DESCRIPTION
Using this package with `npx` is a little more complicated than some packages due to there being multiple entry points / binaries exposed (`storybook-to-ghpages` and `storybook-to-aws-s3`). In this case you must use `npx -p` which is a lesser known feature of `npx`, so worth documenting.